### PR TITLE
Use full class names in fixtures for simplicity

### DIFF
--- a/dispatcher.yml
+++ b/dispatcher.yml
@@ -1,20 +1,19 @@
 # Demo config
 ---
 pool:
-  max_workers: 3
+  max_workers: 4
 producers:
-  brokers:
-    # List of channels to listen on
+  BrokeredProducer:
+    broker: pg_notify
+    config:
+      conninfo: dbname=dispatch_db user=dispatch password=dispatching host=localhost port=55777
     channels:
     - test_channel
     - test_channel2
     - test_channel3
-    pg_notify:
-      # Database connection details
-      conninfo: dbname=dispatch_db user=dispatch password=dispatching host=localhost
-        port=55777
-  scheduled:
-    'lambda: __import__("time").sleep(1)':
-      schedule: 3
-    'lambda: __import__("time").sleep(2)':
-      schedule: 3
+  ScheduledProducer:
+    task_schedule:
+      'lambda: __import__("time").sleep(1)':
+        schedule: 3
+      'lambda: __import__("time").sleep(2)':
+        schedule: 3

--- a/dispatcher/main.py
+++ b/dispatcher/main.py
@@ -7,9 +7,6 @@ from typing import Optional, Union
 
 from dispatcher.pool import WorkerPool
 from dispatcher import producers as producer_module
-# from dispatcher.producers.base import BaseProducer
-# from dispatcher.producers.brokered import BrokeredProducer
-# from dispatcher.producers.scheduled import ScheduledProducer
 
 logger = logging.getLogger(__name__)
 

--- a/dispatcher/main.py
+++ b/dispatcher/main.py
@@ -5,8 +5,8 @@ import signal
 from types import SimpleNamespace
 from typing import Optional, Union
 
-from dispatcher.pool import WorkerPool
 from dispatcher import producers as producer_module
+from dispatcher.pool import WorkerPool
 
 logger = logging.getLogger(__name__)
 

--- a/dispatcher/main.py
+++ b/dispatcher/main.py
@@ -6,9 +6,10 @@ from types import SimpleNamespace
 from typing import Optional, Union
 
 from dispatcher.pool import WorkerPool
-from dispatcher.producers.base import BaseProducer
-from dispatcher.producers.brokered import BrokeredProducer
-from dispatcher.producers.scheduled import ScheduledProducer
+from dispatcher import producers as producer_module
+# from dispatcher.producers.base import BaseProducer
+# from dispatcher.producers.brokered import BrokeredProducer
+# from dispatcher.producers.scheduled import ScheduledProducer
 
 logger = logging.getLogger(__name__)
 
@@ -83,18 +84,12 @@ class DispatcherMain:
         self.pool = WorkerPool(config.get('pool', {}).get('max_workers', 3), self.fd_lock)
 
         # Initialize all the producers, this should not start anything, just establishes objects
-        self.producers: list[Union[ScheduledProducer, BrokeredProducer]] = []
+        self.producers: list[Union[producer_module.ScheduledProducer, producer_module.BrokeredProducer]] = []
         if 'producers' in config:
-            producer_config = config['producers']
-            if 'brokers' in producer_config:
-                for broker_name, broker_config in producer_config['brokers'].items():
-                    # TODO: import from the broker module here, some importlib stuff
-                    # TODO: make channels specific to broker, probably
-                    if broker_name != 'pg_notify':
-                        continue
-                    self.producers.append(BrokeredProducer(broker=broker_name, config=broker_config, channels=producer_config['brokers']['channels']))
-            if 'scheduled' in producer_config:
-                self.producers.append(ScheduledProducer(producer_config['scheduled']))
+            all_producer_config = config['producers']
+            for cls_name, producer_config in all_producer_config.items():
+                producer_cls = getattr(producer_module, cls_name)
+                self.producers.append(producer_cls(**producer_config))
 
         self.events = self._create_events()
 
@@ -159,7 +154,7 @@ class DispatcherMain:
         logger.debug('Setting event to exit main loop')
         self.events.exit_event.set()
 
-    async def connected_callback(self, producer: BaseProducer) -> None:
+    async def connected_callback(self, producer: producer_module.BaseProducer) -> None:
         return
 
     async def sleep_then_process(self, capsule: SimpleNamespace) -> None:
@@ -179,7 +174,7 @@ class DispatcherMain:
         capsule.task = new_task
         self.delayed_messages.append(capsule)
 
-    async def process_message(self, payload: dict, broker: Optional[BrokeredProducer] = None, channel: Optional[str] = None) -> None:
+    async def process_message(self, payload: dict, broker: Optional[producer_module.BrokeredProducer] = None, channel: Optional[str] = None) -> None:
         # Convert payload from client into python dict
         # TODO: more structured validation of the incoming payload from publishers
         if isinstance(payload, str):

--- a/dispatcher/producers/__init__.py
+++ b/dispatcher/producers/__init__.py
@@ -2,5 +2,4 @@ from .base import BaseProducer
 from .brokered import BrokeredProducer
 from .scheduled import ScheduledProducer
 
-
 __all__ = ['BaseProducer', 'BrokeredProducer', 'ScheduledProducer']

--- a/dispatcher/producers/__init__.py
+++ b/dispatcher/producers/__init__.py
@@ -1,0 +1,6 @@
+from .base import BaseProducer
+from .brokered import BrokeredProducer
+from .scheduled import ScheduledProducer
+
+
+__all__ = ['BaseProducer', 'BrokeredProducer', 'ScheduledProducer']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,8 @@ async def aconnection_for_test():
         # Make sure database is running to avoid deadlocks which can come
         # from using the loop provided by pytest asyncio
         async with conn.cursor() as cursor:
-            cursor.execute('SELECT 1')
-            cursor.fetchall()
+            await cursor.execute('SELECT 1')
+            await cursor.fetchall()
 
         yield conn
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,41 @@ CHANNELS = ['test_channel', 'test_channel2', 'test_channel3']
 # Database connection details
 CONNECTION_STRING = "dbname=dispatch_db user=dispatch password=dispatching host=localhost port=55777"
 
-BASIC_CONFIG = {"producers": {"brokers": {"pg_notify": {"conninfo": CONNECTION_STRING}, "channels": CHANNELS}}, "pool": {"max_workers": 3}}
+BASIC_CONFIG = {
+    "producers": {
+        "BrokeredProducer": {
+            # fixture fills in connection details
+            "broker": "pg_notify",
+            "channels": CHANNELS
+        }
+    },
+    "pool": {
+        "max_workers": 3
+    }
+}
+
+
+@contextlib.asynccontextmanager
+async def aconnection_for_test():
+    conn = None
+    try:
+        conn = await aget_connection({'conninfo': CONNECTION_STRING})
+
+        # Make sure database is running to avoid deadlocks which can come
+        # from using the loop provided by pytest asyncio
+        async with conn.cursor() as cursor:
+            cursor.execute('SELECT 1')
+            cursor.fetchall()
+
+        yield conn
+    finally:
+        if conn:
+            await conn.close()
+
+
+@pytest.fixture
+def conn_config():
+    return {'conninfo': CONNECTION_STRING}
 
 
 @pytest.fixture
@@ -29,18 +63,25 @@ def pg_dispatcher() -> DispatcherMain:
 
 
 @pytest_asyncio.fixture(loop_scope="function", scope="function")
-async def apg_dispatcher(request) -> AsyncIterator[DispatcherMain]:
-    try:
-        dispatcher = DispatcherMain(BASIC_CONFIG)
+async def apg_dispatcher(conn_config) -> AsyncIterator[DispatcherMain]:
+    # need to make a new connection because it can not be same as publisher
+    async with aconnection_for_test() as conn:
+        config = BASIC_CONFIG.copy()
+        config['producers']['BrokeredProducer']['connection'] = conn
+        # We have to fill in the config so that replies can still be sent in workers
+        # the workers may establish a new psycopg connection
+        config['producers']['BrokeredProducer']['config'] = conn_config
+        try:
+            dispatcher = DispatcherMain(config)
 
-        await dispatcher.connect_signals()
-        await dispatcher.start_working()
-        await dispatcher.wait_for_producers_ready()
+            await dispatcher.connect_signals()
+            await dispatcher.start_working()
+            await dispatcher.wait_for_producers_ready()
 
-        yield dispatcher
-    finally:
-        await dispatcher.shutdown()
-        await dispatcher.cancel_tasks()
+            yield dispatcher
+        finally:
+            await dispatcher.shutdown()
+            await dispatcher.cancel_tasks()
 
 
 @pytest_asyncio.fixture(loop_scope="function", scope="function")
@@ -48,22 +89,6 @@ async def pg_message(psycopg_conn) -> Callable:
     async def _rf(message, channel='test_channel'):
         await apublish_message(psycopg_conn, channel, message)
     return _rf
-
-
-@pytest.fixture
-def conn_config():
-    return {'conninfo': CONNECTION_STRING}
-
-
-@contextlib.asynccontextmanager
-async def aconnection_for_test():
-    conn = None
-    try:
-        conn = await aget_connection({'conninfo': CONNECTION_STRING})
-        yield conn
-    finally:
-        if conn:
-            await conn.close()
 
 
 @pytest_asyncio.fixture(loop_scope="function", scope="function")


### PR DESCRIPTION
This is a contract change, and anything that initializes the dispatcher will have to update to correspond.

Using the full class names is more verbose, but for several reasons winds up being more simple in the end. This changes the demo to use this structure as well as the tests. Addresses a few TODO items from when the desired structure wasn't yet pinned down.

Also does some connection juggling in the test fixtures - because previously the tests would hang if postgres was not running. The way around that is the `SELECT 1` test added here, and that is passed into the config, intertwined with the other changes to how components are referenced.