### PR TITLE
Add task timeout

### DIFF
--- a/dispatcher/main.py
+++ b/dispatcher/main.py
@@ -71,6 +71,13 @@ class ControlTasks:
         return
 
 
+class DispatcherEvents:
+    "Benchmark tests have to re-create this because they use same object in different event loops"
+
+    def __init__(self) -> None:
+        self.exit_event: asyncio.Event = asyncio.Event()
+
+
 class DispatcherMain:
     def __init__(self, config: dict):
         self.delayed_messages: list[SimpleNamespace] = []
@@ -97,11 +104,7 @@ class DispatcherMain:
             if 'scheduled' in producer_config:
                 self.producers.append(ScheduledProducer(producer_config['scheduled']))
 
-        self.events = self._create_events()
-
-    def _create_events(self):
-        "Benchmark tests have to re-create this because they use same object in different event loops"
-        return SimpleNamespace(exit_event=asyncio.Event())
+        self.events: DispatcherEvents = DispatcherEvents()
 
     def fatal_error_callback(self, *args) -> None:
         """Method to connect to error callbacks of other tasks, will kick out of main loop"""

--- a/dispatcher/pool.py
+++ b/dispatcher/pool.py
@@ -314,7 +314,6 @@ class WorkerPool:
         return None
 
     async def dispatch_task(self, message: dict) -> None:
-        logger.info(f'message {message}')
         async with self.management_lock:
             uuid = message.get("uuid", "<unknown>")
 

--- a/dispatcher/pool.py
+++ b/dispatcher/pool.py
@@ -174,7 +174,10 @@ class WorkerPool:
 
             # Established that worker is running a task that has a timeout
             if worker_deadline < current_time:
-                # worker gets timed out right now
+                uuid = worker.current_task.get('uuid', '<unknown>')
+                timeout = worker.current_task.get('timeout')
+                delta = current_time - worker.started_at
+                logger.info(f'Worker {worker.worker_id} runtime {delta:.5f}(s) for task uuid={uuid} exceeded timeout {timeout}(s), canceling')
                 worker.cancel()
             elif next_deadline is None or worker_deadline < next_deadline:
                 # worker timeout is closer than any yet seen

--- a/dispatcher/producers/base.py
+++ b/dispatcher/producers/base.py
@@ -1,7 +1,10 @@
 import asyncio
-from types import SimpleNamespace
+
+
+class ProducerEvents:
+    def __init__(self):
+        self.ready_event = asyncio.Event()
 
 
 class BaseProducer:
-    def _create_events(self):
-        return SimpleNamespace(ready_event=asyncio.Event())
+    pass

--- a/dispatcher/producers/brokered.py
+++ b/dispatcher/producers/brokered.py
@@ -3,14 +3,14 @@ import logging
 from typing import Optional
 
 from dispatcher.brokers.pg_notify import aget_connection, aprocess_notify, apublish_message
-from dispatcher.producers.base import BaseProducer
+from dispatcher.producers.base import BaseProducer, ProducerEvents
 
 logger = logging.getLogger(__name__)
 
 
 class BrokeredProducer(BaseProducer):
     def __init__(self, broker: str = 'pg_notify', config: Optional[dict] = None, channels: tuple = (), connection=None) -> None:
-        self.events = self._create_events()
+        self.events = ProducerEvents()
         self.production_task: Optional[asyncio.Task] = None
         self.broker = broker
         self.config = config

--- a/dispatcher/producers/scheduled.py
+++ b/dispatcher/producers/scheduled.py
@@ -1,14 +1,14 @@
 import asyncio
 import logging
 
-from dispatcher.producers.base import BaseProducer
+from dispatcher.producers.base import BaseProducer, ProducerEvents
 
 logger = logging.getLogger(__name__)
 
 
 class ScheduledProducer(BaseProducer):
     def __init__(self, task_schedule: dict):
-        self.events = self._create_events()
+        self.events = ProducerEvents()
         self.task_schedule = task_schedule
         self.scheduled_tasks: list[asyncio.Task] = []
         self.produced_count = 0

--- a/dispatcher/registry.py
+++ b/dispatcher/registry.py
@@ -43,7 +43,10 @@ class DispatcherMethod:
         return self.fn
 
     def publication_defaults(self) -> dict:
-        defaults = self.submission_defaults.copy()
+        defaults = {}
+        for k, v in self.submission_defaults.items():
+            if v:  # all None or falsy values have no effect
+                defaults[k] = v
         defaults['task'] = self.serialize_task()
         defaults['time_pub'] = time.time()
         return defaults
@@ -51,7 +54,7 @@ class DispatcherMethod:
     def delay(self, *args, **kwargs) -> Tuple[dict, str]:
         return self.apply_async(args, kwargs)
 
-    def get_async_body(self, args=None, kwargs=None, uuid=None, on_duplicate: Optional[str] = None, delay: float = 0.0) -> dict:
+    def get_async_body(self, args=None, kwargs=None, uuid=None, on_duplicate: Optional[str] = None, timeout: Optional[float] = 0.0, delay: float = 0.0) -> dict:
         """
         Get the python dict to become JSON data in the pg_notify message
         This same message gets passed over the dispatcher IPC queue to workers
@@ -67,6 +70,8 @@ class DispatcherMethod:
             body['on_duplicate'] = on_duplicate
         if delay:
             body['delay'] = delay
+        if timeout:
+            body['timeout'] = timeout
 
         return body
 

--- a/tests/integration/test_pool.py
+++ b/tests/integration/test_pool.py
@@ -7,13 +7,14 @@ import pytest
 from tests.data import methods as test_methods
 
 SLEEP_METHOD = 'lambda: __import__("time").sleep(1.5)'
+LIGHT_SLEEP_METHOD = 'lambda: __import__("time").sleep(0.03)'
 
 
 @pytest.mark.asyncio
 async def test_task_timeout(apg_dispatcher, pg_message):
     assert apg_dispatcher.pool.finished_count == 0
 
-    start_time = time.monotonic_ns()
+    start_time = time.monotonic()
 
     clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
     await pg_message(json.dumps({
@@ -22,7 +23,50 @@ async def test_task_timeout(apg_dispatcher, pg_message):
     }))
     await asyncio.wait_for(clearing_task, timeout=3)
 
-    delta = time.monotonic_ns() - start_time
+    delta = time.monotonic() - start_time
 
     assert delta < 1.0  # proves task did not run to completion
     assert apg_dispatcher.pool.canceled_count == 1
+
+
+@pytest.mark.asyncio
+async def test_multiple_task_timeouts(apg_dispatcher, pg_message):
+    assert apg_dispatcher.pool.finished_count == 0
+
+    start_time = time.monotonic()
+
+    clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
+    for i in range(5):
+        await pg_message(json.dumps({
+            'task': SLEEP_METHOD,
+            'timeout': 0.01*i + 0.01,
+            'uuid': f'test_multiple_task_timeouts_{i}'
+        }))
+    await asyncio.wait_for(clearing_task, timeout=3)
+
+    delta = time.monotonic() - start_time
+
+    assert delta < 1.0  # proves task did not run to completion
+    assert apg_dispatcher.pool.canceled_count == 5
+
+
+@pytest.mark.asyncio
+async def test_mixed_timeouts_non_timeouts(apg_dispatcher, pg_message):
+    assert apg_dispatcher.pool.finished_count == 0
+
+    start_time = time.monotonic()
+
+    clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
+    for i in range(6):
+        await pg_message(json.dumps({
+            'task': SLEEP_METHOD if (i % 2) else LIGHT_SLEEP_METHOD,
+            'timeout': 0.01 * (i % 2),
+            'uuid': f'test_multiple_task_timeouts_{i}'
+        }))
+    await asyncio.wait_for(clearing_task, timeout=3)
+
+    delta = time.monotonic() - start_time
+
+    assert delta < 1.0
+    # half of the tasks should be finished, half should have been canceled
+    assert apg_dispatcher.pool.canceled_count == 3

--- a/tests/integration/test_pool.py
+++ b/tests/integration/test_pool.py
@@ -13,7 +13,7 @@ SLEEP_METHOD = 'lambda: __import__("time").sleep(1.5)'
 async def test_task_timeout(apg_dispatcher, pg_message):
     assert apg_dispatcher.pool.finished_count == 0
 
-    start_time = time.monotonic()
+    start_time = time.monotonic_ns()
 
     clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
     await pg_message(json.dumps({
@@ -22,7 +22,7 @@ async def test_task_timeout(apg_dispatcher, pg_message):
     }))
     await asyncio.wait_for(clearing_task, timeout=3)
 
-    delta = time.monotonic() - start_time
+    delta = time.monotonic_ns() - start_time
 
     assert delta < 1.0  # proves task did not run to completion
     assert apg_dispatcher.pool.canceled_count == 1

--- a/tests/integration/test_pool.py
+++ b/tests/integration/test_pool.py
@@ -1,0 +1,28 @@
+import time
+import asyncio
+import json
+
+import pytest
+
+from tests.data import methods as test_methods
+
+SLEEP_METHOD = 'lambda: __import__("time").sleep(1.5)'
+
+
+@pytest.mark.asyncio
+async def test_task_timeout(apg_dispatcher, pg_message):
+    assert apg_dispatcher.pool.finished_count == 0
+
+    start_time = time.monotonic()
+
+    clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
+    await pg_message(json.dumps({
+        'task': SLEEP_METHOD,
+        'timeout': 0.1
+    }))
+    await asyncio.wait_for(clearing_task, timeout=3)
+
+    delta = time.monotonic() - start_time
+
+    assert delta < 1.0  # proves task did not run to completion
+    assert apg_dispatcher.pool.canceled_count == 1

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from dispatcher.registry import InvalidMethod
@@ -30,3 +32,13 @@ def test_no_objects(registry):
 
     with pytest.raises(InvalidMethod):
         registry.register(SomeClass())
+
+
+def test_register_with_timeout(registry):
+    "Tests that a timeout set at the task level will be submitted"
+    def test_method():
+        time.sleep(4)  # will not actually run
+
+    dmethod = registry.register(test_method, timeout=0.2)
+    submit_data = dmethod.get_async_body()
+    assert submit_data['timeout'] == 0.2

--- a/tools/test_methods.py
+++ b/tools/test_methods.py
@@ -21,3 +21,8 @@ def sleep_serial(seconds=1):
 @task(queue='test_channel')
 def print_hello():
     print('hello world!!')
+
+
+@task(queue='test_channel', timeout=1)
+def task_has_timeout():
+    time.sleep(5)

--- a/tools/write_messages.py
+++ b/tools/write_messages.py
@@ -15,7 +15,7 @@ tools_dir = os.path.abspath(
 
 sys.path.append(tools_dir)
 
-from test_methods import print_hello, sleep_function, sleep_discard
+from test_methods import sleep_function, sleep_discard, task_has_timeout
 
 # Database connection details
 CONNECTION_STRING = "dbname=dispatch_db user=dispatch password=dispatching host=localhost port=55777"
@@ -107,6 +107,9 @@ def main():
         publish_message(channel, json.dumps(
             {'task': 'lambda: __import__("time").sleep(8)', 'on_duplicate': 'queue_one', 'uuid': f'queue_one-{i}'}
         ), config={'conninfo': CONNECTION_STRING})
+
+    print('demo of task_has_timeout that times out due to decorator use')
+    task_has_timeout.apply_async(config={'conninfo': CONNECTION_STRING})
 
 if __name__ == "__main__":
     logging.basicConfig(level='ERROR', stream=sys.stdout)


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcher/issues/54

~Obviously this needs an integration test~, but I wanted to just get implementation structure now. It is functional, tested with the demo script.

EDIT: added tests

```
ERROR:dispatcher.worker.task:Worker 1 task canceled (uuid=1db13c11-a50a-4b0a-91c7-8cbc401c7436)
Traceback (most recent call last):
  File "/home/arominge/repos/dispatcher/dispatcher/worker/task.py", line 84, in run_callable
    return _call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arominge/repos/dispatcher/tools/test_methods.py", line 28, in task_has_timeout
    time.sleep(5)
  File "/home/arominge/repos/dispatcher/dispatcher/worker/task.py", line 31, in task_cancel
    raise DispatcherCancel
dispatcher.worker.task.DispatcherCancel
DEBUG:dispatcher.pool:Worker 1 finished task (uuid=1db13c11-a50a-4b0a-91c7-8cbc401c7436), ct=16, expected cancel, canceled
```

There are some aesthetic changes we could make, like call it "timeout" instead of "cancel"... but obviously timeout uses the same mechanism as cancel. Maybe I'll just rename the exception to `DispatcherInterrupt` or something like that.

Also, I'm relatively happy with the structure, although it took some thought. I implemented "delayed" task in the "main" part of the code. It's non-obvious that timeouts will go in the pool part, but the pool can gate on capacity, and timeouts don't start until the worker actually starts running it. And this is definitely something we want enforced in the parent, in general.