### PR TITLE
Drop the unnecessary `wheel` entry from build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 Repository = "https://github.com/ansible/dispatcher"
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
It was never needed to begin with, as `setuptools` would auto-depend on it when building wheels in the past, anyway. But nowadays, `wheel` moved inside of `setuptools` even (during last year's PyCon US Sprints, and I was helping a bit, actually).