### PR TITLE
Register control tasks in their own registry and add "worker" command

### DIFF
--- a/dispatcher/main.py
+++ b/dispatcher/main.py
@@ -145,7 +145,7 @@ class DispatcherMain:
             try:
                 dmethod = control_registry.get_method(message['control'])
                 control_data = message.get('control_data', {})
-                returned = await dmethod.fn(self, **control_data)
+                returned = await dmethod.afn(self, **control_data)
             except Exception as exc:
                 returned = f'No control method {message["control"]}, error: {str(exc)}'
 

--- a/dispatcher/pool.py
+++ b/dispatcher/pool.py
@@ -48,7 +48,7 @@ class PoolWorker:
             'finished_count': 0,
             'current_task': self.current_task.get('task') if self.current_task else None,
             'current_task_uuid': self.current_task.get('uuid', '<unknown>') if self.current_task else None,
-            'active_cancel': self.is_active_cancel
+            'active_cancel': self.is_active_cancel,
         }
 
     async def stop(self) -> None:

--- a/dispatcher/pool.py
+++ b/dispatcher/pool.py
@@ -40,6 +40,17 @@ class PoolWorker:
         logger.debug(f'Joining worker {self.worker_id} pid={self.process.pid} subprocess')
         self.process.join()
 
+    def get_data(self):
+        return {
+            'worker_id': self.worker_id,
+            'pid': self.process.pid,
+            'status': self.status,
+            'finished_count': 0,
+            'current_task': self.current_task.get('task') if self.current_task else None,
+            'current_task_uuid': self.current_task.get('uuid', '<unknown>') if self.current_task else None,
+            'active_cancel': self.is_active_cancel
+        }
+
     async def stop(self) -> None:
         self.process.message_queue.put("stop")
         if self.current_task:

--- a/dispatcher/registry.py
+++ b/dispatcher/registry.py
@@ -111,7 +111,7 @@ class UnregisteredMethod(DispatcherMethod):
 
 
 class DispatcherMethodRegistry:
-    method_cls = DispatcherMethod
+    method_cls: type = DispatcherMethod
 
     def __init__(self) -> None:
         self.registry: Set[DispatcherMethodBase] = set()

--- a/dispatcher/tasks.py
+++ b/dispatcher/tasks.py
@@ -1,8 +1,89 @@
+import asyncio
+import logging
+from typing import Optional
+
+from dispatcher.registry import control_registry
 from dispatcher.factories import get_publisher_from_settings
 from dispatcher.publish import task
+
+
+logger = logging.getLogger(__name__)
 
 
 @task()
 def reply_to_control(reply_channel: str, message: str):
     broker = get_publisher_from_settings()
     broker.publish_message(channel=reply_channel, message=message)
+
+
+def task_filter_match(pool_task: dict, msg_data: dict) -> bool:
+    """The two messages are functionally the same or not"""
+    filterables = ('task', 'args', 'kwargs', 'uuid')
+    for key in filterables:
+        expected_value = msg_data.get(key)
+        if expected_value:
+            if pool_task.get(key, None) != expected_value:
+                return False
+    return True
+
+
+async def _find_tasks(dispatcher, cancel: bool = False, **data) -> list[tuple[Optional[str], dict]]:
+    "Utility method used for both running and cancel control methods"
+    ret = []
+    for worker in dispatcher.pool.workers.values():
+        if worker.current_task:
+            if task_filter_match(worker.current_task, data):
+                if cancel:
+                    logger.warning(f'Canceling task in worker {worker.worker_id}, task: {worker.current_task}')
+                    worker.cancel()
+                ret.append((worker.worker_id, worker.current_task))
+    for message in dispatcher.pool.queued_messages:
+        if task_filter_match(message, data):
+            if cancel:
+                logger.warning(f'Canceling task in pool queue: {message}')
+                dispatcher.pool.queued_messages.remove(message)
+            ret.append((None, message))
+    for capsule in dispatcher.delayed_messages.copy():
+        if task_filter_match(capsule.message, data):
+            if cancel:
+                logger.warning(f'Canceling delayed task (uuid={capsule.uuid})')
+                capsule.task.cancel()
+                try:
+                    await capsule.task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    logger.error(f'Error canceling delayed task (uuid={capsule.uuid})')
+                dispatcher.delayed_messages.remove(capsule)
+            ret.append(('<delayed>', capsule.message))
+    return ret
+
+
+def control_task(fn):
+    control_registry.register(fn)
+
+
+# TODO: hold pool management lock for these things
+@control_task
+async def running(dispatcher, **data) -> list[tuple[Optional[str], dict]]:
+    # TODO: include delayed tasks in results
+    return await _find_tasks(dispatcher, **data)
+
+
+@control_task
+async def cancel(dispatcher, **data) -> list[tuple[Optional[str], dict]]:
+    # TODO: include delayed tasks in results
+    return await _find_tasks(dispatcher, cancel=True, **data)
+
+
+@control_task
+async def alive(dispatcher, **data):
+    return
+
+
+@control_task
+async def workers(dispatcher, **data):
+    ret = []
+    for worker in dispatcher.pool.workers.values():
+        ret.append(worker.get_data())
+    return ret

--- a/dispatcher/tasks.py
+++ b/dispatcher/tasks.py
@@ -2,10 +2,9 @@ import asyncio
 import logging
 from typing import Optional
 
-from dispatcher.registry import control_registry
 from dispatcher.factories import get_publisher_from_settings
 from dispatcher.publish import task
-
+from dispatcher.registry import control_registry
 
 logger = logging.getLogger(__name__)
 

--- a/tools/write_messages.py
+++ b/tools/write_messages.py
@@ -54,6 +54,12 @@ def main():
     print(json.dumps(canceled_jobs, indent=2))
 
     print('')
+    print('getting worker status')
+    ctl = Control('test_channel', config={'conninfo': CONNECTION_STRING})
+    worker_data = ctl.control_with_reply('workers')
+    print(json.dumps(worker_data, indent=2))
+
+    print('')
     print('finding a running task by its task name')
     broker.publish_message(message=json.dumps({'task': 'lambda: __import__("time").sleep(3.1415)', 'uuid': 'foobar2'}))
     running_data = ctl.control_with_reply('running', data={'task': 'lambda: __import__("time").sleep(3.1415)'})


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcher/issues/58

This moves control tasks to `dispatcher/tasks.py`, which the config work also adds some stuff to.

This also adds a "worker" command, which is the closest analog to current `awx-manage run_dispatcher --status`. This is only tested in a demo context at the moment:

```
getting worker status
[
  [
    {
      "worker_id": 0,
      "pid": 171787,
      "status": "ready",
      "finished_count": 0,
      "current_task": "lambda: __import__(\"time\").sleep(3.1415)",
      "current_task_uuid": "foobar",
      "active_cancel": false
    },
    {
      "worker_id": 1,
      "pid": 171788,
      "status": "ready",
      "finished_count": 0,
      "current_task": null,
      "current_task_uuid": null,
      "active_cancel": false
    },
    {
      "worker_id": 2,
      "pid": 171790,
      "status": "ready",
      "finished_count": 0,
      "current_task": "lambda: __import__(\"time\").sleep(1)",
      "current_task_uuid": "internal-4",
      "active_cancel": false
    }
  ]
]
```

And yes, I seem to have neglected to increment the worker `finished_count`, I think I have that fixed somewhere else.