### PR TITLE
Allow using forkserver

### DIFF
--- a/dispatcher/pool.py
+++ b/dispatcher/pool.py
@@ -4,7 +4,7 @@ import time
 from asyncio import Task
 from typing import Iterator, Optional
 
-from dispatcher.process import ProcessManager, ProcessProxy
+from dispatcher.process import ForkServerManager, ProcessProxy
 from dispatcher.utils import DuplicateBehavior, MessageAction
 
 logger = logging.getLogger(__name__)
@@ -98,7 +98,7 @@ class WorkerPool:
         self.num_workers = num_workers
         self.workers: dict[int, PoolWorker] = {}
         self.next_worker_id = 0
-        self.process_manager = ProcessManager()
+        self.process_manager = ForkServerManager()
         self.queued_messages: list[dict] = []  # TODO: use deque, invent new kinds of logging anxiety
         self.read_results_task: Optional[Task] = None
         self.start_worker_task: Optional[Task] = None

--- a/dispatcher/process.py
+++ b/dispatcher/process.py
@@ -1,14 +1,15 @@
 import asyncio
 import multiprocessing
-from typing import Callable, Iterable, Optional, Union
+from multiprocessing.context import BaseContext
+from typing import Callable, Iterable, Optional, Union, Sized
 
 from dispatcher.worker.task import work_loop
 
 
 class ProcessProxy:
-    def __init__(self, args: Iterable, finished_queue: multiprocessing.Queue, target: Callable = work_loop) -> None:
-        self.message_queue: multiprocessing.Queue = multiprocessing.Queue()
-        self._process = multiprocessing.Process(target=target, args=tuple(args) + (self.message_queue, finished_queue))
+    def __init__(self, args: Iterable, finished_queue: multiprocessing.Queue, target: Callable = work_loop, ctx: BaseContext = multiprocessing) -> None:
+        self.message_queue: multiprocessing.Queue = ctx.Queue()
+        self._process = ctx.Process(target=target, args=tuple(args) + (self.message_queue, finished_queue))
 
     def start(self) -> None:
         self._process.start()
@@ -37,8 +38,11 @@ class ProcessProxy:
 
 
 class ProcessManager:
+    mp_context = 'fork'
+
     def __init__(self) -> None:
-        self.finished_queue: multiprocessing.Queue = multiprocessing.Queue()
+        self.ctx = multiprocessing.get_context(self.mp_context)
+        self.finished_queue: multiprocessing.Queue = self.ctx.Queue()
         self._loop = None
 
     def get_event_loop(self):
@@ -47,8 +51,16 @@ class ProcessManager:
         return self._loop
 
     def create_process(self, args: Iterable[int | str], **kwargs) -> ProcessProxy:
-        return ProcessProxy(args, self.finished_queue, **kwargs)
+        return ProcessProxy(args, self.finished_queue, ctx=self.ctx, **kwargs)
 
     async def read_finished(self) -> dict[str, Union[str, int]]:
         message = await self.get_event_loop().run_in_executor(None, self.finished_queue.get)
         return message
+
+
+class ForkServerManager(ProcessManager):
+    mp_context = 'forkserver'
+
+    def __init__(self, preload_modules: Sized = ()):
+        super().__init__()
+        self.ctx.set_forkserver_preload(preload_modules)


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcher/issues/39

I had another idea to do a callback hook that would set up Django, and employ a `hazmat.py` module in dispatcher. But I've abandoned that, because it's very non-obvious and adds muddies the contract with the app. If it's important, the app can set up such a module itself and pass it in the parameter, which is added here.

This isn't yet coherent to configure, and that will be delayed until https://github.com/ansible/dispatcher/pull/64 gets in. It's a bit hard because it's nested down low to:
 - DispatcherMain
   - WorkerPool
     - ProcessManager

So that's 3 levels deep, and that's something to be cleaned up with the factories logic.