### PR TITLE
Fix integration bugs between scheduled producer, `@task` decorator and registry

### DIFF
--- a/dispatcher/producers/scheduled.py
+++ b/dispatcher/producers/scheduled.py
@@ -14,8 +14,9 @@ class ScheduledProducer(BaseProducer):
 
     async def start_producing(self, dispatcher) -> None:
         for task_name, options in self.task_schedule.items():
-            per_seconds = options['schedule']
-            schedule_task = asyncio.create_task(self.run_schedule_forever(task_name, per_seconds, dispatcher))
+            submission_options = options.copy()
+            per_seconds = submission_options.pop('schedule')
+            schedule_task = asyncio.create_task(self.run_schedule_forever(task_name, per_seconds, dispatcher, submission_options))
             self.scheduled_tasks.append(schedule_task)
             schedule_task.add_done_callback(dispatcher.fatal_error_callback)
         if self.events:
@@ -24,13 +25,16 @@ class ScheduledProducer(BaseProducer):
     def all_tasks(self) -> list[asyncio.Task]:
         return self.scheduled_tasks
 
-    async def run_schedule_forever(self, task_name: str, per_seconds, dispatcher) -> None:
+    async def run_schedule_forever(self, task_name: str, per_seconds, dispatcher, submission_options) -> None:
         logger.info(f"Starting task runner for {task_name} with interval {per_seconds} seconds")
         while True:
             await asyncio.sleep(per_seconds)
             logger.debug(f"Produced scheduled task: {task_name}")
             self.produced_count += 1
-            await dispatcher.process_message({'task': task_name, 'uuid': f'sch-{self.produced_count}'})
+            message = submission_options.copy()
+            message['task'] = task_name
+            message['uuid'] = f'sch-{self.produced_count}'
+            await dispatcher.process_message(message)
 
     async def shutdown(self) -> None:
         logger.info('Stopping scheduled tasks')

--- a/tests/data/nested/methods.py
+++ b/tests/data/nested/methods.py
@@ -1,0 +1,14 @@
+from dispatcher.publish import task
+
+from tests.data.nested.nested_registry import surprised_registry
+
+"""
+This module is intended to never be imported at top-of-file by tests
+this creates the situation of a, valid, but "surprise" registration
+to challenge our registry logic.
+"""
+
+
+@task(queue='test_channel', registry=surprised_registry)
+def print_hello():
+    print('hello world!!')

--- a/tests/data/nested/nested_registry.py
+++ b/tests/data/nested/nested_registry.py
@@ -1,0 +1,14 @@
+from dispatcher.registry import DispatcherMethodRegistry
+
+"""
+This hosts a registry that has nothing in it
+until the test test_surprise_registration looks up a method
+in a not-yet-imported module, and then SURPRISE,
+the module the method lives in registers the method.
+
+But that will not happen until the test runs.
+So do not tell the registry until then, meaning,
+do not import methods.py before running that test.
+"""
+
+surprised_registry = DispatcherMethodRegistry()

--- a/tests/unit/service/producers/test_scheduled_producer.py
+++ b/tests/unit/service/producers/test_scheduled_producer.py
@@ -1,0 +1,42 @@
+import asyncio
+
+import pytest
+
+from dispatcher.producers import ScheduledProducer
+
+
+class ItWorked(Exception):
+    pass
+
+
+class Dispatcher:
+    def __init__(self):
+        self.test_done = asyncio.Event()
+
+    async def process_message(self, message):
+        assert message.get('on_duplicate') == 'queue_one'
+        assert 'schedule' not in message
+        raise ItWorked
+
+    async def fatal_error_callback(self, *args, **kwargs):
+        raise Exception('task error')
+
+
+async def run_schedules_for_a_while(producer):
+    dispatcher = Dispatcher()
+    await producer.start_producing(dispatcher)
+    for task in producer.all_tasks():
+        await task
+
+
+def test_scheduled_producer_with_options():
+    producer = ScheduledProducer({
+        'tests.data.methods.print_hello': {
+            'schedule': 0.1,
+            'on_duplicate': 'queue_one'
+        }
+    })
+
+    loop = asyncio.get_event_loop()
+    with pytest.raises(ItWorked):
+        loop.run_until_complete(run_schedules_for_a_while(producer))

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -2,7 +2,8 @@ import time
 
 import pytest
 
-from dispatcher.registry import InvalidMethod
+from dispatcher.registry import InvalidMethod, DispatcherMethodRegistry, DispatcherMethod, UnregisteredMethod
+from tests.data.nested.nested_registry import surprised_registry
 
 
 def test_registry_ordinary_method(registry):
@@ -42,3 +43,18 @@ def test_register_with_timeout(registry):
     dmethod = registry.register(test_method, timeout=0.2)
     submit_data = dmethod.get_async_body()
     assert submit_data['timeout'] == 0.2
+
+
+def test_surprise_registration():
+    """Finds a registered method in registry
+
+    where the method is not registered until the lookup happens
+    this is important so that if the user does not pre-load the registry
+    at import time, the parameters of registered methods are still respected
+    """
+    assert len(surprised_registry.lookup_dict) == 0
+    dmethod = surprised_registry.get_method('tests.data.nested.methods.print_hello')
+    assert len(surprised_registry.registry) == 1  # we grew!
+    assert len(surprised_registry.lookup_dict) == 1
+    assert isinstance(dmethod, DispatcherMethod)
+    assert not isinstance(dmethod, UnregisteredMethod)

--- a/tests/unit/worker/test_task_worker.py
+++ b/tests/unit/worker/test_task_worker.py
@@ -1,0 +1,20 @@
+from dispatcher.worker.task import TaskWorker
+from dispatcher.publish import task
+
+
+# Must define here to be importable
+def my_bound_task(dispatcher):
+    assert dispatcher.uuid == '12345'
+
+
+def test_run_method_with_bind(registry):
+
+    task(bind=True, registry=registry)(my_bound_task)
+
+    dmethod = registry.get_from_callable(my_bound_task)
+
+    worker = TaskWorker(1, registry=registry)
+    worker.run_callable({
+        "task": dmethod.serialize_task(),
+        "uuid": "12345"
+    })


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcher/issues/82

There's 3 semi-related things going on, so I'll go through in the order in which I approached them.

1. Scheduled tasks didn't properly respect `bind=True`, because all the registry logic was never adopted in the ScheduledProducer, like, at all. But the fix _for this_ assuming that imports are already in place, is to move the application of the "bind" argument, specifically to the worker. Why only this? It just happens to be the only option that affects behavior on the worker, and does not affect behavior in the parent process. It's just... the only one that does that.
2. Remember that qualifier "assuming that imports are already in place". Well this isn't a good assumption. So if they're not, we'll have a "miss", not finding the method in the registry even through it has a `@task()` on it. The solution is to double-check an instance variable on the registry to see if the import of the method affects the registry itself. The test is super duper cheeky. But I find these methods acceptable, because it's the only way to get the coverage we need, in an isolated way. And the tests are "our" space for improving software quality. So if I need to add a special purpose module, I don't see why I can't.
3. Remember how the "bind" option is the only one applied in the worker. What about all the other options, like `on_duplicate`? Doesn't `ScheduledProducer` need to apply those too? Unfortunately I don't have a solution, because this leaves me at a philosophical crisis. More-and-more, we have leaned into a strict environment separation between the dispatcher and the Django app. We don't set up Django in the dispatcher. The user can, that's not our business. But the dispatcher _shouldn't_ and maybe _can't_ import the scheduled methods in the main asyncio code. It should only know them by their name. Forcing importing will bring in dirty stuff. So for now I'm adding a **workaround** so that you can put method options directly in the schedule spec.