### PR TITLE
Send reply messages from the main process

### DIFF
--- a/dispatcher/brokers/pg_notify.py
+++ b/dispatcher/brokers/pg_notify.py
@@ -32,7 +32,7 @@ def create_connection(**config) -> psycopg.Connection:
 
 
 class Broker:
-    NOTIFY_SYNTAX = 'SELECT pg_notify(%s, %s);'
+    NOTIFY_QUERY_TEMPLATE = 'SELECT pg_notify(%s, %s);'
 
     def __init__(
         self,
@@ -136,7 +136,7 @@ class Broker:
 
     async def apublish_message_from_cursor(self, cursor: psycopg.AsyncCursor, channel: Optional[str] = None, message: str = '') -> None:
         """The inner logic of async message publishing where we already have a cursor"""
-        await cursor.execute(self.NOTIFY_SYNTAX, (channel, message))
+        await cursor.execute(self.NOTIFY_QUERY_TEMPLATE, (channel, message))
 
     async def apublish_message(self, channel: Optional[str] = None, message: str = '') -> None:  # public
         """asyncio way to publish a message, used to send control in control-and-reply
@@ -183,7 +183,7 @@ class Broker:
         channel = self.get_publish_channel(channel)
 
         with connection.cursor() as cur:
-            cur.execute(self.NOTIFY_SYNTAX, (channel, message))
+            cur.execute(self.NOTIFY_QUERY_TEMPLATE, (channel, message))
 
         logger.debug(f'Sent pg_notify message of {len(message)} chars to {channel}')
 

--- a/dispatcher/brokers/pg_notify.py
+++ b/dispatcher/brokers/pg_notify.py
@@ -132,7 +132,7 @@ class Broker:
                     await self.apublish_message_from_cursor(cur, channel=reply_to, message=reply_message)
                 self.notify_queue = []
 
-    async def apublish_message_from_cursor(self, cursor: psycopg.AsyncClientCursor, channel: Optional[str] = None, message: str = '') -> None:
+    async def apublish_message_from_cursor(self, cursor: psycopg.AsyncCursor, channel: Optional[str] = None, message: str = '') -> None:
         """The inner logic of async message publishing where we already have a cursor"""
         if not message:
             await cursor.execute(f'NOTIFY {channel};')

--- a/dispatcher/control.py
+++ b/dispatcher/control.py
@@ -35,6 +35,7 @@ class ControlCallbacks:
         self.received_replies.append(payload)
         if self.expected_replies and (len(self.received_replies) >= self.expected_replies):
             self.events.exit_event.set()
+        return (None, None)
 
     async def connected_callback(self, producer) -> None:
         payload = json.dumps(self.send_data)

--- a/dispatcher/control.py
+++ b/dispatcher/control.py
@@ -22,16 +22,18 @@ class ControlCallbacks:
     it exists to interact with producers, using variables relevant to the particular
     control message being sent"""
 
-    def __init__(self, queuename, send_data, expected_replies):
+    def __init__(self, queuename, send_data, expected_replies) -> None:
         self.queuename = queuename
         self.send_data = send_data
         self.expected_replies = expected_replies
 
-        self.received_replies = []
+        # received_replies only tracks the reply message, not the channel name
+        # because they come via a temporary reply_to channel and that is not user-facing
+        self.received_replies: list[str] = []
         self.events = ControlEvents()
         self.shutting_down = False
 
-    async def process_message(self, payload, producer=None, channel=None):
+    async def process_message(self, payload, producer=None, channel=None) -> tuple[Optional[str], Optional[str]]:
         self.received_replies.append(payload)
         if self.expected_replies and (len(self.received_replies) >= self.expected_replies):
             self.events.exit_event.set()
@@ -42,7 +44,7 @@ class ControlCallbacks:
         await producer.notify(channel=self.queuename, message=payload)
         logger.info('Sent control message, expecting replies soon')
 
-    def fatal_error_callback(self, *args):
+    def fatal_error_callback(self, *args) -> None:
         if self.shutting_down:
             return
 

--- a/dispatcher/producers/brokered.py
+++ b/dispatcher/producers/brokered.py
@@ -36,7 +36,10 @@ class BrokeredProducer(BaseProducer):
         self.dispatcher = dispatcher
         async for channel, payload in self.broker.aprocess_notify(connected_callback=self.connected_callback):
             self.produced_count += 1
-            await dispatcher.process_message(payload, producer=self, channel=channel)
+            reply_to, reply_payload = await dispatcher.process_message(payload, producer=self, channel=channel)
+            if reply_to:
+                logger.info(f'Sending reply via broker {self.broker} to channel {reply_to} with data:\n{reply_payload}')
+                await self.notify(channel=reply_to, message=reply_payload)
 
     async def notify(self, channel: Optional[str] = None, message: str = '') -> None:
         await self.broker.apublish_message(channel=channel, message=message)

--- a/dispatcher/producers/brokered.py
+++ b/dispatcher/producers/brokered.py
@@ -38,7 +38,6 @@ class BrokeredProducer(BaseProducer):
             self.produced_count += 1
             reply_to, reply_payload = await dispatcher.process_message(payload, producer=self, channel=channel)
             if reply_to:
-                logger.info(f'Sending reply via broker {self.broker} to channel {reply_to} with data:\n{reply_payload}')
                 await self.notify(channel=reply_to, message=reply_payload)
 
     async def notify(self, channel: Optional[str] = None, message: str = '') -> None:

--- a/dispatcher/service/main.py
+++ b/dispatcher/service/main.py
@@ -170,7 +170,9 @@ class DispatcherMain:
         capsule.task = new_task
         self.delayed_messages.append(capsule)
 
-    async def process_message(self, payload: dict, producer: Optional[BaseProducer] = None, channel: Optional[str] = None) -> tuple[Optional[str],Optional[str]]:
+    async def process_message(
+        self, payload: dict, producer: Optional[BaseProducer] = None, channel: Optional[str] = None
+    ) -> tuple[Optional[str], Optional[str]]:
         """Called by producers to trigger a new task
 
         Convert payload from producer into python dict
@@ -204,7 +206,7 @@ class DispatcherMain:
             return await self.process_message_internal(message, producer=producer)
         return (None, None)
 
-    async def process_message_internal(self, message: dict, producer=None) -> tuple[Optional[str],Optional[str]]:
+    async def process_message_internal(self, message: dict, producer=None) -> tuple[Optional[str], Optional[str]]:
         """Route message based on needed action - delay for later, return reply, or dispatch to worker"""
         if 'control' in message:
             method = getattr(self.ctl_tasks, message['control'])

--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -107,7 +107,6 @@ class WorkerPool:
         self.start_worker_task: Optional[Task] = None
         self.shutting_down = False
         self.finished_count: int = 0
-        self.control_count: int = 0
         self.canceled_count: int = 0
         self.discard_count: int = 0
         self.shutdown_timeout = 3
@@ -369,8 +368,6 @@ class WorkerPool:
         async with self.management_lock:
             if worker.is_active_cancel and result == '<cancel>':
                 self.canceled_count += 1
-            elif 'control' in worker.current_task:
-                self.control_count += 1
             else:
                 self.finished_count += 1
             worker.mark_finished_task()

--- a/dispatcher/service/tasks.py
+++ b/dispatcher/service/tasks.py
@@ -1,8 +1,0 @@
-from ..factories import get_publisher_from_settings
-from ..publish import task
-
-
-@task()
-def reply_to_control(reply_channel: str, message: str):
-    broker = get_publisher_from_settings()
-    broker.publish_message(channel=reply_channel, message=message)

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -100,7 +100,7 @@ async def test_cancel_task(apg_dispatcher, pg_message, pg_control):
     await asyncio.wait_for(clearing_task, timeout=3)
 
     pool = apg_dispatcher.pool
-    assert [pool.finished_count, pool.canceled_count, pool.control_count] == [0, 1, 1], 'cts: [finished, canceled, control]'
+    assert [pool.finished_count, pool.canceled_count, apg_dispatcher.control_count] == [0, 1, 1], 'cts: [finished, canceled, control]'
 
 
 @pytest.mark.asyncio
@@ -117,13 +117,10 @@ async def test_message_with_delay(apg_dispatcher, pg_message, pg_control):
     assert running_job['uuid'] == 'delay_task'
     await asyncio.wait_for(apg_dispatcher.pool.events.work_cleared.wait(), timeout=3)
     pool = apg_dispatcher.pool
-    assert [pool.finished_count, pool.canceled_count, pool.control_count] == [0, 0, 1], 'cts: [finished, canceled, control]'
-    # Completing the reply itself will be a work_cleared event, so we have to clear the event
-    apg_dispatcher.pool.events.work_cleared.clear()
 
     # Wait for task to finish, assertions after completion
     await asyncio.wait_for(apg_dispatcher.pool.events.work_cleared.wait(), timeout=3)
-    assert [pool.finished_count, pool.canceled_count, pool.control_count] == [1, 0, 1], 'cts: [finished, canceled, control]'
+    assert [pool.finished_count, pool.canceled_count, apg_dispatcher.control_count] == [1, 0, 1], 'cts: [finished, canceled, control]'
 
 
 @pytest.mark.asyncio

--- a/tools/write_messages.py
+++ b/tools/write_messages.py
@@ -4,8 +4,7 @@ import logging
 import os
 import sys
 
-from dispatcher.factories import get_publisher_from_settings
-from dispatcher.control import Control
+from dispatcher.factories import get_publisher_from_settings, get_control_from_settings
 from dispatcher.utils import MODULE_METHOD_DELIMITER
 from dispatcher.config import setup
 
@@ -49,7 +48,7 @@ def main():
     print('performing a task cancel')
     # submit a task we will "find" two different ways
     broker.publish_message(message=json.dumps({'task': 'lambda: __import__("time").sleep(3.1415)', 'uuid': 'foobar'}))
-    ctl = Control('test_channel')
+    ctl = get_control_from_settings()
     canceled_jobs = ctl.control_with_reply('cancel', data={'uuid': 'foobar'})
     print(json.dumps(canceled_jobs, indent=2))
 


### PR DESCRIPTION
This changes the implementation of the control-and-reply pattern so that reply messages are sent directly from the main asyncio code, instead of sending them back using the workers in synchronous code.

I had previously attempted this and failed, discovering that it would hang when trying to send the reply. After giving it another shot today, I discovered that this behavior is described in https://github.com/psycopg/psycopg/issues/340 upstream. This implements a solution that is compliant with the suggested use of the psycopg library, which is that we exit the `async for` loop before sending the reply, and then continue the `while True:` loop which already exists.

### Why did I not do this before? (other than the obvious reason it didn't work)

There are some trade-offs involved, in the AWX dispatcher, we used a different connection to send the reply. This is a bad idea, but more-so for error handling and consistency reasons, as opposed to timing reasons. Action on that separate connection _generally_ caused blocking problems, but the act of sending a reply is not really the main culprit. I still had a thought that it would be better to farm this work to the workers.

### Why do those reasons not apply here?

As much as the reply message would have been blocking in the AWX dispatcher, this implementation would be _less_ blocking because it is bona fide asyncio code. If this does pose any delays in getting new messages, that's probably because we're sunk capacity-wise or with other errors. In those cases, getting debugging information (which the replies do) would be a higher priority than whatever those new messages say.

Also, I've been shifting further and further to the idea of _relying_ on the control-and-reply pattern to replace heartbeat logic. With that as a goal, this is undoubtedly the correct thing to do.

### Usability implications

With this, the demo script now runs in <1 second, and is rock-solid reliable. Before this, it didn't. That's because the demo over-and-over-again submitted more work than the 4 workers had capacity to handle (intentionally). Now, no "work" blocks the demo script logic. This is also relevant for eda-server as it uses the "alive" message as a replacement for some rq-worker stuff.