### PR TITLE
Producer for running tasks on start

### DIFF
--- a/dispatcher.yml
+++ b/dispatcher.yml
@@ -21,5 +21,8 @@ producers:
         schedule: 3
       'lambda: __import__("time").sleep(2)':
         schedule: 3
+  OnStartProducer:
+    task_list:
+      'lambda: print("This task runs on startup")': {}
 publish:
   default_broker: pg_notify

--- a/dispatcher/producers/__init__.py
+++ b/dispatcher/producers/__init__.py
@@ -1,6 +1,6 @@
 from .base import BaseProducer
 from .brokered import BrokeredProducer
-from .scheduled import ScheduledProducer
 from .on_start import OnStartProducer
+from .scheduled import ScheduledProducer
 
 __all__ = ['BaseProducer', 'BrokeredProducer', 'ScheduledProducer', 'OnStartProducer']

--- a/dispatcher/producers/__init__.py
+++ b/dispatcher/producers/__init__.py
@@ -1,5 +1,6 @@
 from .base import BaseProducer
 from .brokered import BrokeredProducer
 from .scheduled import ScheduledProducer
+from .on_start import OnStartProducer
 
-__all__ = ['BaseProducer', 'BrokeredProducer', 'ScheduledProducer']
+__all__ = ['BaseProducer', 'BrokeredProducer', 'ScheduledProducer', 'OnStartProducer']

--- a/dispatcher/producers/on_start.py
+++ b/dispatcher/producers/on_start.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from typing import Union
 
 from .base import BaseProducer
 
@@ -7,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class OnStartProducer(BaseProducer):
-    def __init__(self, task_list: dict[str, dict[str, int]]):
+    def __init__(self, task_list: dict[str, dict[str, Union[int, str]]]):
         self.task_list = task_list
         super().__init__()
 

--- a/dispatcher/producers/on_start.py
+++ b/dispatcher/producers/on_start.py
@@ -1,0 +1,30 @@
+import asyncio
+import logging
+
+from .base import BaseProducer
+
+logger = logging.getLogger(__name__)
+
+
+class OnStartProducer(BaseProducer):
+    def __init__(self, task_list: dict[str, dict[str, int]]):
+        self.task_list = task_list
+        super().__init__()
+
+    async def start_producing(self, dispatcher) -> None:
+        self.events.ready_event.set()
+
+        for task_name, options in self.task_list.items():
+            message = options.copy()
+            message['task'] = task_name
+            message['uuid'] = f'on-start-{self.produced_count}'
+
+            logger.debug(f"Produced on-start task: {task_name}")
+            self.produced_count += 1
+            await dispatcher.process_message(message)
+
+    def all_tasks(self) -> list[asyncio.Task]:
+        return []
+
+    async def shutdown(self) -> None:
+        pass

--- a/dispatcher/producers/scheduled.py
+++ b/dispatcher/producers/scheduled.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from typing import Union
 
 from .base import BaseProducer
 
@@ -7,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class ScheduledProducer(BaseProducer):
-    def __init__(self, task_schedule: dict[str, dict[str, int]]):
+    def __init__(self, task_schedule: dict[str, dict[str, Union[int, str]]]):
         self.task_schedule = task_schedule
         self.scheduled_tasks: list[asyncio.Task] = []
         super().__init__()

--- a/docs/config.md
+++ b/docs/config.md
@@ -116,8 +116,9 @@ For every listed broker, a `BrokeredProducer` is automatically
 created. That means that tasks may be produced from the messaging
 system that the dispatcher service is listening to.
 
-The other current use case is `ScheduledProducer`,
-which submits tasks every certain number of seconds.
+The others are:
+ - `ScheduledProducer` - submits tasks every certain number of seconds
+ - `OnStartProducer` - runs tasks once after starting
 
 #### Publish
 

--- a/schema.json
+++ b/schema.json
@@ -11,7 +11,10 @@
   },
   "producers": {
     "ScheduledProducer": {
-      "task_schedule": "dict[str, dict[str, int]]"
+      "task_schedule": "dict[str, dict[str, typing.Union[int, str]]]"
+    },
+    "OnStartProducer": {
+      "task_list": "dict[str, dict[str, typing.Union[int, str]]]"
     }
   },
   "service": {


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcher/issues/79

You can see this in the output for the demo:

```
INFO:dispatcher.service.main:Connecting dispatcher signal handling
DEBUG:dispatcher.service.main:Filling the worker pool
DEBUG:dispatcher.service.main:Starting task production
DEBUG:dispatcher.producers.on_start:Produced on-start task: lambda: print("This task runs on startup")
WARNING:dispatcher.service.pool:Queueing task (uuid=on-start-0), ran out of workers, queued_ct=0
INFO:dispatcher.service.main:Dispatcher running forever, or until shutdown command
DEBUG:dispatcher.service.pool:Starting subprocess for worker 0
DEBUG:dispatcher.service.pool:Worker 0 pid=437154 subprocess has spawned
DEBUG:dispatcher.service.pool:Starting subprocess for worker 1
DEBUG:dispatcher.service.pool:Worker 1 pid=437155 subprocess has spawned
DEBUG:dispatcher.service.pool:Starting subprocess for worker 2
DEBUG:dispatcher.service.pool:Worker 2 pid=437157 subprocess has spawned
DEBUG:dispatcher.service.pool:Starting subprocess for worker 3
DEBUG:dispatcher.service.pool:Worker 3 pid=437159 subprocess has spawned
INFO:dispatcher.producers.scheduled:Starting task runner for lambda: __import__("time").sleep(1) with interval 3 seconds
INFO:dispatcher.producers.scheduled:Starting task runner for lambda: __import__("time").sleep(2) with interval 3 seconds
DEBUG:dispatcher.service.pool:Dispatching task (uuid=on-start-0) to worker (id=0)
DEBUG:dispatcher.worker.task:task (uuid=on-start-0) starting lambda: print("This task runs on startup")(*[]) on worker 0
This task runs on startup
```
