### PR TITLE
Add "worker" control command, add `node_id` to identify service

### DIFF
--- a/dispatcher.yml
+++ b/dispatcher.yml
@@ -4,6 +4,8 @@ version: 2
 service:
   pool_kwargs:
     max_workers: 4
+  main_kwargs:
+    node_id: demo-server-a
 brokers:
   pg_notify:
     config:

--- a/dispatcher/factories.py
+++ b/dispatcher/factories.py
@@ -125,6 +125,7 @@ def generate_settings_schema(settings: LazySettings = global_settings) -> dict:
     ret = deepcopy(settings.serialize())
 
     ret['service']['pool_kwargs'] = schema_for_cls(WorkerPool)
+    ret['service']['main_kwargs'] = schema_for_cls(DispatcherMain)
     ret['service']['process_manager_kwargs'] = {}
     pm_classes = (process.ProcessManager, process.ForkServerManager)
     for pm_cls in pm_classes:

--- a/dispatcher/factories.py
+++ b/dispatcher/factories.py
@@ -58,7 +58,8 @@ def from_settings(settings: LazySettings = global_settings) -> DispatcherMain:
     """
     producers = producers_from_settings(settings=settings)
     pool = pool_from_settings(settings=settings)
-    return DispatcherMain(producers, pool)
+    extra_kwargs = settings.service.get('main_kwargs', {})
+    return DispatcherMain(producers, pool, **extra_kwargs)
 
 
 # ---- Publisher objects ----

--- a/dispatcher/service/control_tasks.py
+++ b/dispatcher/service/control_tasks.py
@@ -1,0 +1,73 @@
+import asyncio
+import logging
+from typing import Optional
+
+
+__all__ = ['running', 'cancel', 'alive', 'workers']
+
+
+logger = logging.getLogger(__name__)
+
+
+def task_filter_match(pool_task: dict, msg_data: dict) -> bool:
+    """The two messages are functionally the same or not"""
+    filterables = ('task', 'args', 'kwargs', 'uuid')
+    for key in filterables:
+        expected_value = msg_data.get(key)
+        if expected_value:
+            if pool_task.get(key, None) != expected_value:
+                return False
+    return True
+
+
+async def _find_tasks(dispatcher, cancel: bool = False, **data) -> list[tuple[Optional[str], dict]]:
+    "Utility method used for both running and cancel control methods"
+    ret = {}
+    for worker in dispatcher.pool.workers.values():
+        if worker.current_task:
+            if task_filter_match(worker.current_task, data):
+                if cancel:
+                    logger.warning(f'Canceling task in worker {worker.worker_id}, task: {worker.current_task}')
+                    worker.cancel()
+                ret[f'worker-{worker.worker_id}'] = worker.current_task
+    for i, message in enumerate(dispatcher.pool.queued_messages):
+        if task_filter_match(message, data):
+            if cancel:
+                logger.warning(f'Canceling task in pool queue: {message}')
+                dispatcher.pool.queued_messages.remove(message)
+            ret[f'queued-{i}'] = message
+    for i, capsule in enumerate(dispatcher.delayed_messages.copy()):
+        if task_filter_match(capsule.message, data):
+            if cancel:
+                logger.warning(f'Canceling delayed task (uuid={capsule.uuid})')
+                capsule.task.cancel()
+                try:
+                    await capsule.task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    logger.error(f'Error canceling delayed task (uuid={capsule.uuid})')
+                dispatcher.delayed_messages.remove(capsule)
+            ret[f'delayed-{i}'] = capsule.message
+    return ret
+
+
+async def running(dispatcher, **data) -> dict[str, dict]:
+    async with dispatcher.pool.management_lock:
+        return await _find_tasks(dispatcher, **data)
+
+
+async def cancel(dispatcher, **data) -> dict[str, dict]:
+    async with dispatcher.pool.management_lock:
+        return await _find_tasks(dispatcher, cancel=True, **data)
+
+
+async def alive(dispatcher, **data) -> dict:
+    return {}
+
+
+async def workers(dispatcher, **data) -> dict:
+    ret = {}
+    for worker in dispatcher.pool.workers.values():
+        ret[f'worker-{worker.worker_id}'] = worker.get_data()
+    return ret

--- a/dispatcher/service/control_tasks.py
+++ b/dispatcher/service/control_tasks.py
@@ -1,7 +1,5 @@
 import asyncio
 import logging
-from typing import Optional
-
 
 __all__ = ['running', 'cancel', 'alive', 'workers']
 
@@ -20,7 +18,7 @@ def task_filter_match(pool_task: dict, msg_data: dict) -> bool:
     return True
 
 
-async def _find_tasks(dispatcher, cancel: bool = False, **data) -> list[tuple[Optional[str], dict]]:
+async def _find_tasks(dispatcher, cancel: bool = False, **data) -> dict[str, dict]:
     "Utility method used for both running and cancel control methods"
     ret = {}
     for worker in dispatcher.pool.workers.values():

--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import time
 from asyncio import Task
-from typing import Iterator, Optional, Any
+from typing import Any, Iterator, Optional
 
 from ..config import LazySettings
 from ..config import settings as global_settings
@@ -83,7 +83,7 @@ class PoolWorker:
             'current_task': self.current_task.get('task') if self.current_task else None,
             'current_task_uuid': self.current_task.get('uuid', '<unknown>') if self.current_task else None,
             'active_cancel': self.is_active_cancel,
-            'age': time.monotonic() - self.created_at
+            'age': time.monotonic() - self.created_at,
         }
 
     def mark_finished_task(self) -> None:

--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -79,7 +79,7 @@ class PoolWorker:
             'worker_id': self.worker_id,
             'pid': self.process.pid,
             'status': self.status,
-            'finished_count': 0,
+            'finished_count': self.finished_count,
             'current_task': self.current_task.get('task') if self.current_task else None,
             'current_task_uuid': self.current_task.get('uuid', '<unknown>') if self.current_task else None,
             'active_cancel': self.is_active_cancel,

--- a/run_demo.py
+++ b/run_demo.py
@@ -53,6 +53,16 @@ def main():
     running_data = ctl.control_with_reply('running', data={'task': 'lambda: __import__("time").sleep(3.1415)'})
     print(json.dumps(running_data, indent=2))
 
+    print('')
+    print('getting worker status')
+    worker_data = ctl.control_with_reply('workers')
+    print(json.dumps(worker_data, indent=2))
+
+    print('')
+    print('run bogus control command')
+    worker_data = ctl.control_with_reply('not-a-command')
+    print(json.dumps(worker_data, indent=2))
+
     print('writing a message with a delay')
     print('     4 second delay task')
     broker.publish_message(message=json.dumps({'task': 'lambda: 123421', 'uuid': 'foobar2', 'delay': 4}))

--- a/schema.json
+++ b/schema.json
@@ -24,7 +24,10 @@
     "process_manager_kwargs": {
       "preload_modules": "typing.Optional[list[str]]"
     },
-    "process_manager_cls": "typing.Literal['ProcessManager', 'ForkServerManager']"
+    "process_manager_cls": "typing.Literal['ProcessManager', 'ForkServerManager']",
+    "main_kwargs": {
+      "node_id": "typing.Optional[str]"
+    }
   },
   "publish": {
     "default_broker": "str"


### PR DESCRIPTION
This is a re-do of https://github.com/ansible/dispatcher/pull/76 that takes the good and leaves the bad. I'm still going to mark it:

Fixes https://github.com/ansible/dispatcher/issues/58

Even though the design has changed.

### Demo Output

```
$ ./run_demo.py 
writing some basic test messages

writing 15 messages fast

 -------- Actions involving control-and-reply ---------

performing a task cancel
[
  {
    "queued-16": {
      "task": "lambda: __import__(\"time\").sleep(3.1415)",
      "uuid": "foobar",
      "channel": "test_channel"
    },
    "node_id": "1b0e8049-88f1-48d7-94b5-fc3e1761f4d0"
  }
]

finding a running task by its task name
[
  {
    "queued-16": {
      "task": "lambda: __import__(\"time\").sleep(3.1415)",
      "uuid": "foobar2",
      "channel": "test_channel"
    },
    "node_id": "1b0e8049-88f1-48d7-94b5-fc3e1761f4d0"
  }
]

getting worker status
[
  {
    "worker-0": {
      "worker_id": 0,
      "pid": 959233,
      "status": "ready",
      "finished_count": 0,
      "current_task": "lambda: __import__(\"time\").sleep(1)",
      "current_task_uuid": "sch-1",
      "active_cancel": false,
      "age": 3.4361121260008076
    },
    "worker-1": {
      "worker_id": 1,
      "pid": 959234,
      "status": "ready",
      "finished_count": 0,
      "current_task": "lambda: __import__(\"time\").sleep(2)",
      "current_task_uuid": "sch-2",
      "active_cancel": false,
      "age": 3.436063063010806
    },
    "worker-2": {
      "worker_id": 2,
      "pid": 959236,
      "status": "ready",
      "finished_count": 0,
      "current_task": "lambda: __import__(\"time\").sleep(1)",
      "current_task_uuid": "internal-3",
      "active_cancel": false,
      "age": 3.4360159619973274
    },
    "worker-3": {
      "worker_id": 3,
      "pid": 959238,
      "status": "ready",
      "finished_count": 0,
      "current_task": "lambda: __import__(\"time\").sleep(1)",
      "current_task_uuid": "internal-4",
      "active_cancel": false,
      "age": 3.4359764230030123
    },
    "node_id": "1b0e8049-88f1-48d7-94b5-fc3e1761f4d0"
  }
]

run bogus control command
[
  {
    "error": "No control method not-a-command",
    "node_id": "1b0e8049-88f1-48d7-94b5-fc3e1761f4d0"
  }
]
writing a message with a delay
     4 second delay task
     30 second delay task

 -------- Using tasks defined with @task() decorator ---------

running tests.data.methods.sleep_function with a delay
     10 second delay task

showing delayed tasks in running list
[
  {
    "delayed-2": {
      "queue": "test_channel",
      "task": "tests.data.methods.sleep_function",
      "time_pub": 1740630215.5885904,
      "uuid": "6d387c62-6ea2-4690-9a29-f1fc528185fd",
      "args": [
        3
      ],
      "kwargs": {},
      "delay": 10,
      "channel": "test_channel"
    },
    "node_id": "1b0e8049-88f1-48d7-94b5-fc3e1761f4d0"
  }
]

cancel a delayed task with no reply for demonstration
confirmation that it has been canceled
[
  {
    "node_id": "1b0e8049-88f1-48d7-94b5-fc3e1761f4d0"
  }
]

running alive check a few times
[{'node_id': '1b0e8049-88f1-48d7-94b5-fc3e1761f4d0'}]
[{'node_id': '1b0e8049-88f1-48d7-94b5-fc3e1761f4d0'}]
[{'node_id': '1b0e8049-88f1-48d7-94b5-fc3e1761f4d0'}]

demo of submitting discarding tasks
demo of discarding task marked as discarding
demo of discarding tasks with apply_async contract
demo of submitting waiting tasks
demo of submitting queue-once tasks
demo of task_has_timeout that times out due to decorator use
demo of using bind=True, with hello_world_binder
```