### PR TITLE
Pass settings in process, not pool, class. Use kwargs for `work_loop`

### DIFF
--- a/dispatcher/factories.py
+++ b/dispatcher/factories.py
@@ -24,12 +24,11 @@ which is to avoid import dependencies.
 def process_manager_from_settings(settings: LazySettings = global_settings):
     cls_name = settings.service.get('process_manager_cls', 'ForkServerManager')
     process_manager_cls = getattr(process, cls_name)
-    return process_manager_cls()
+    return process_manager_cls(settings=settings)
 
 
 def pool_from_settings(settings: LazySettings = global_settings):
     kwargs = settings.service.get('pool_kwargs', {}).copy()
-    kwargs['settings'] = settings
     kwargs['process_manager'] = process_manager_from_settings(settings=settings)
     return WorkerPool(**kwargs)
 

--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -198,7 +198,7 @@ class WorkerPool:
             self.events.timeout_event.clear()
 
     async def up(self) -> None:
-        process = self.process_manager.create_process((self.next_worker_id,))
+        process = self.process_manager.create_process(kwargs={'worker_id': self.next_worker_id})
         worker = PoolWorker(self.next_worker_id, process)
         self.workers[self.next_worker_id] = worker
         self.next_worker_id += 1

--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -4,8 +4,6 @@ import time
 from asyncio import Task
 from typing import Any, Iterator, Optional
 
-from ..config import LazySettings
-from ..config import settings as global_settings
 from ..utils import DuplicateBehavior, MessageAction
 from .process import ProcessManager, ProcessProxy
 
@@ -110,10 +108,9 @@ class PoolEvents:
 
 
 class WorkerPool:
-    def __init__(self, max_workers: int, process_manager: ProcessManager, settings: LazySettings = global_settings):
+    def __init__(self, max_workers: int, process_manager: ProcessManager):
         self.max_workers = max_workers
         self.workers: dict[int, PoolWorker] = {}
-        self.settings_stash: dict = settings.serialize()  # These are passed to the workers to initialize dispatcher settings
         self.next_worker_id = 0
         self.process_manager = process_manager
         self.queued_messages: list[dict] = []  # TODO: use deque, invent new kinds of logging anxiety
@@ -201,12 +198,7 @@ class WorkerPool:
             self.events.timeout_event.clear()
 
     async def up(self) -> None:
-        process = self.process_manager.create_process(
-            (
-                self.settings_stash,
-                self.next_worker_id,
-            )
-        )
+        process = self.process_manager.create_process((self.next_worker_id,))
         worker = PoolWorker(self.next_worker_id, process)
         self.workers[self.next_worker_id] = worker
         self.next_worker_id += 1

--- a/dispatcher/service/process.py
+++ b/dispatcher/service/process.py
@@ -4,15 +4,13 @@ from multiprocessing.context import BaseContext
 from types import ModuleType
 from typing import Callable, Iterable, Optional, Union
 
-from ..worker.task import work_loop
 from ..config import LazySettings
 from ..config import settings as global_settings
+from ..worker.task import work_loop
 
 
 class ProcessProxy:
-    def __init__(
-        self, args: Iterable, target: Callable = work_loop, ctx: Union[BaseContext, ModuleType] = multiprocessing
-    ) -> None:
+    def __init__(self, args: Iterable, target: Callable = work_loop, ctx: Union[BaseContext, ModuleType] = multiprocessing) -> None:
         self.message_queue: multiprocessing.Queue = ctx.Queue()
         # This is intended use of multiprocessing context, but not available on BaseContext
         self._process = ctx.Process(target=target, args=tuple(args) + (self.message_queue,))  # type: ignore
@@ -58,7 +56,7 @@ class ProcessManager:
         return self._loop
 
     def create_process(self, args: Iterable[int | str | dict], **kwargs) -> ProcessProxy:
-        return ProcessProxy(args + (self.settings_stash, self.finished_queue), ctx=self.ctx, **kwargs)
+        return ProcessProxy(tuple(args) + (self.settings_stash, self.finished_queue), ctx=self.ctx, **kwargs)
 
     async def read_finished(self) -> dict[str, Union[str, int]]:
         message = await self.get_event_loop().run_in_executor(None, self.finished_queue.get)

--- a/dispatcher/service/process.py
+++ b/dispatcher/service/process.py
@@ -5,15 +5,18 @@ from types import ModuleType
 from typing import Callable, Iterable, Optional, Union
 
 from ..worker.task import work_loop
+from ..config import LazySettings
+from ..config import settings as global_settings
 
+# def work_loop(worker_id: int, queue: multiprocessing.Queue, settings: dict, finished_queue: multiprocessing.Queue) -> None:
 
 class ProcessProxy:
     def __init__(
-        self, args: Iterable, finished_queue: multiprocessing.Queue, target: Callable = work_loop, ctx: Union[BaseContext, ModuleType] = multiprocessing
+        self, args: Iterable, target: Callable = work_loop, ctx: Union[BaseContext, ModuleType] = multiprocessing
     ) -> None:
         self.message_queue: multiprocessing.Queue = ctx.Queue()
         # This is intended use of multiprocessing context, but not available on BaseContext
-        self._process = ctx.Process(target=target, args=tuple(args) + (self.message_queue, finished_queue))  # type: ignore
+        self._process = ctx.Process(target=target, args=tuple(args) + (self.message_queue,))  # type: ignore
 
     def start(self) -> None:
         self._process.start()
@@ -44,9 +47,10 @@ class ProcessProxy:
 class ProcessManager:
     mp_context = 'fork'
 
-    def __init__(self) -> None:
+    def __init__(self, settings: LazySettings = global_settings) -> None:
         self.ctx = multiprocessing.get_context(self.mp_context)
         self.finished_queue: multiprocessing.Queue = self.ctx.Queue()
+        self.settings_stash: dict = settings.serialize()  # These are passed to the workers to initialize dispatcher settings
         self._loop = None
 
     def get_event_loop(self):
@@ -55,7 +59,7 @@ class ProcessManager:
         return self._loop
 
     def create_process(self, args: Iterable[int | str | dict], **kwargs) -> ProcessProxy:
-        return ProcessProxy(args, self.finished_queue, ctx=self.ctx, **kwargs)
+        return ProcessProxy(args + (self.settings_stash, self.finished_queue), ctx=self.ctx, **kwargs)
 
     async def read_finished(self) -> dict[str, Union[str, int]]:
         message = await self.get_event_loop().run_in_executor(None, self.finished_queue.get)
@@ -65,6 +69,6 @@ class ProcessManager:
 class ForkServerManager(ProcessManager):
     mp_context = 'forkserver'
 
-    def __init__(self, preload_modules: Optional[list[str]] = None):
-        super().__init__()
+    def __init__(self, preload_modules: Optional[list[str]] = None, settings: LazySettings = global_settings):
+        super().__init__(settings=settings)
         self.ctx.set_forkserver_preload(preload_modules if preload_modules else [])

--- a/dispatcher/service/process.py
+++ b/dispatcher/service/process.py
@@ -8,7 +8,6 @@ from ..worker.task import work_loop
 from ..config import LazySettings
 from ..config import settings as global_settings
 
-# def work_loop(worker_id: int, queue: multiprocessing.Queue, settings: dict, finished_queue: multiprocessing.Queue) -> None:
 
 class ProcessProxy:
     def __init__(

--- a/dispatcher/worker/task.py
+++ b/dispatcher/worker/task.py
@@ -204,7 +204,7 @@ class TaskWorker:
         return {"worker": self.worker_id, "event": "shutdown"}
 
 
-def work_loop(settings: dict, worker_id: int, queue: multiprocessing.Queue, finished_queue):
+def work_loop(worker_id: int, settings: dict, finished_queue: multiprocessing.Queue, queue: multiprocessing.Queue) -> None:
     """
     Worker function that processes messages from the queue and sends confirmation
     to the finished_queue once done.

--- a/dispatcher/worker/task.py
+++ b/dispatcher/worker/task.py
@@ -204,7 +204,7 @@ class TaskWorker:
         return {"worker": self.worker_id, "event": "shutdown"}
 
 
-def work_loop(worker_id: int, settings: dict, finished_queue: multiprocessing.Queue, queue: multiprocessing.Queue) -> None:
+def work_loop(worker_id: int, settings: dict, finished_queue: multiprocessing.Queue, message_queue: multiprocessing.Queue) -> None:
     """
     Worker function that processes messages from the queue and sends confirmation
     to the finished_queue once done.
@@ -222,7 +222,7 @@ def work_loop(worker_id: int, settings: dict, finished_queue: multiprocessing.Qu
             break
 
         try:
-            message = queue.get()
+            message = message_queue.get()
         except DispatcherCancel:
             logger.info(f'Worker {worker_id} received a task cancel signal in main loop, ignoring')
             continue


### PR DESCRIPTION
Totally random code organization nit this is trying to get out of the way -

When you look at it, it's clear that `WorkerPool` has no right to have `settings` in its kwargs. It does nothing with it other than to pass it on to the `ProcessManager` class. And the factories could just as well pass the settings to that class. So this makes that change.

The hard, ugly, part about this is that the arguments to `work_loop` get reorganized. Right now it's just an ordered list. I would be open to making these kwargs, I think that still works. The approach I'm going with now, is that we just order them in the order in which we build them. So that starts with data from `WorkerPool` and then makes its way in, from left-to-right, outer-to-inner.