### PR TITLE
Fix warning about method not awaited

### DIFF
--- a/tests/unit/service/producers/test_scheduled_producer.py
+++ b/tests/unit/service/producers/test_scheduled_producer.py
@@ -18,7 +18,7 @@ class Dispatcher:
         assert 'schedule' not in message
         raise ItWorked
 
-    async def fatal_error_callback(self, *args, **kwargs):
+    def fatal_error_callback(self, *args, **kwargs):
         raise Exception('task error')
 
 


### PR DESCRIPTION
You can find other definitions of `fatal_error_callback`, and the expectation is that it's synchronous. IIRC, this was more-so error handling of the test, so it's not surprising this slipped by.