### PR TITLE
Fix handling of queues which are callable

### DIFF
--- a/dispatcher/worker/task.py
+++ b/dispatcher/worker/task.py
@@ -105,7 +105,7 @@ class TaskWorker:
         # Any task options used by the worker (here) should come from the registered task, not the message
         # this is to reduce message size, and also because publisher-worker is a shared python environment.
         # Meaning, the service, including some producers, may never see the @task() registration
-        if message.get('bind') is True or dmethod.submission_defaults.get('bind') is True:
+        if message.get('bind') is True or dmethod.bind:
             args = [self.produce_binder(message)] + args
 
         try:

--- a/tests/data/methods.py
+++ b/tests/data/methods.py
@@ -37,3 +37,18 @@ def hello_world_binder(binder):
 @task(queue='test_channel', timeout=1)
 def task_has_timeout():
     time.sleep(5)
+
+
+def get_queue_name():
+    return 'test_channel'
+
+
+@task(queue=get_queue_name)
+def use_callable_queue():
+    print('sucessful run using callable queue')
+
+
+@task(queue=get_queue_name)
+class RunJob:
+    def run(self):
+        print('successful run using callable queue with class')

--- a/tests/integration/test_callable_queues.py
+++ b/tests/integration/test_callable_queues.py
@@ -1,0 +1,108 @@
+import asyncio
+import json
+import pytest
+
+from tests.data import methods as test_methods
+from dispatcher.config import temporary_settings
+
+
+# Function that alternates between valid queue names the dispatcher listens to
+def get_alternating_queue():
+    """Returns a different queue name with each call"""
+    if not hasattr(get_alternating_queue, 'counter'):
+        get_alternating_queue.counter = 0
+    get_alternating_queue.counter += 1
+    return f"test_channel{get_alternating_queue.counter % 2 + 1}"  # returns "test_channel1" or "test_channel2"
+
+
+@pytest.mark.asyncio
+async def test_apply_async_with_callable_queue(apg_dispatcher, test_settings):
+    """Test that apply_async works with callable queues"""
+    # Reset state for test
+    apg_dispatcher.pool.events.work_cleared.clear()
+    initial_count = apg_dispatcher.pool.finished_count
+
+    # Create a task to wait for completion
+    clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
+
+    # Using apply_async instead of delay with a callable that returns a valid queue
+    with temporary_settings(test_settings.serialize()):
+        test_methods.print_hello.apply_async(queue=lambda: "test_channel")
+
+    # Wait for task to complete with timeout
+    await asyncio.wait_for(clearing_task, timeout=3)
+
+    # Verify task completed
+    assert apg_dispatcher.pool.finished_count == initial_count + 1
+
+
+@pytest.mark.asyncio
+async def test_callable_queue_at_submission_time(apg_dispatcher, test_settings):
+    """Test that a callable queue works when provided at submission time"""
+    # Reset state for test
+    apg_dispatcher.pool.events.work_cleared.clear()
+    initial_count = apg_dispatcher.pool.finished_count
+
+    # Create a task to wait for completion
+    clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
+
+    # Using a callable queue at submission time, not at decoration time
+    with temporary_settings(test_settings.serialize()):
+        test_methods.print_hello.apply_async(queue=lambda: "test_channel")
+
+    # Wait for task to complete with timeout
+    await asyncio.wait_for(clearing_task, timeout=3)
+
+    # Verify task completed
+    assert apg_dispatcher.pool.finished_count == initial_count + 1
+
+
+@pytest.mark.asyncio
+async def test_alternating_queue_names(apg_dispatcher, test_settings):
+    """Test that a callable returning different queue names works correctly"""
+    # Reset for first task
+    apg_dispatcher.pool.events.work_cleared.clear()
+    initial_count = apg_dispatcher.pool.finished_count
+
+    # Set up first task
+    clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
+
+    # Use a static queue to make sure the test is well-controlled
+    with temporary_settings(test_settings.serialize()):
+        test_methods.print_hello.apply_async(queue="test_channel")
+
+    # Wait for first task to complete
+    await asyncio.wait_for(clearing_task, timeout=3)
+    assert apg_dispatcher.pool.finished_count == initial_count + 1
+
+    # Set up second task with a different queue
+    apg_dispatcher.pool.events.work_cleared.clear()
+    second_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
+
+    with temporary_settings(test_settings.serialize()):
+        test_methods.print_hello.apply_async(queue="test_channel2")
+
+    # Wait for second task to complete
+    await asyncio.wait_for(second_task, timeout=3)
+    assert apg_dispatcher.pool.finished_count == initial_count + 2
+
+
+def test_callable_queue_json_serializable():
+    """Test that a callable queue is properly handled for JSON serialization"""
+    from dispatcher.registry import DispatcherMethod
+
+    def test_func():
+        pass
+
+    def get_queue():
+        return "result_queue"
+
+    # Test with a callable queue
+    method = DispatcherMethod(test_func, queue=get_queue)
+
+    # The message for async body should be JSON serializable
+    message = method.get_async_body()
+    assert json.dumps(message)  # Should not raise exception
+
+    # The callable should not be included in the message
+    assert 'queue' not in message


### PR DESCRIPTION
Discovered bug in:

https://github.com/AlanCoding/awx/tree/feature_dispatcher

```
In [14]: [dmethod for dmethod in registry.registry][0].get_async_body()
Out[14]: 
{'queue': <function awx.main.dispatch.get_task_queuename()>,
 'task': 'awx.main.tasks.host_metrics.host_metric_summary_monthly',
 'time_pub': 1740675110.0686553,
 'uuid': '9efbb136-2dee-4189-91fd-6edf99c9ce79',
 'args': [],
 'kwargs': {}}
```

This data is supposed to be JSON-ifable information only, and AWX uses this heavily with a callable queue.