### PR TITLE
[WIP] Standardize periodic task runners

### DIFF
--- a/dispatcher/service/control_tasks.py
+++ b/dispatcher/service/control_tasks.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 __all__ = ['running', 'cancel', 'alive', 'workers']
@@ -37,14 +36,9 @@ async def _find_tasks(dispatcher, cancel: bool = False, **data) -> dict[str, dic
     for i, capsule in enumerate(dispatcher.delayed_messages.copy()):
         if task_filter_match(capsule.message, data):
             if cancel:
-                logger.warning(f'Canceling delayed task (uuid={capsule.uuid})')
-                capsule.task.cancel()
-                try:
-                    await capsule.task
-                except asyncio.CancelledError:
-                    pass
-                except Exception:
-                    logger.error(f'Error canceling delayed task (uuid={capsule.uuid})')
+                uuid = capsule.message.get('uuid', '<unknown>')
+                logger.warning(f'Canceling delayed task (uuid={uuid})')
+                capsule.has_ran = True  # make sure we do not run by accident
                 dispatcher.delayed_messages.remove(capsule)
             ret[f'delayed-{i}'] = capsule.message
     return ret

--- a/dispatcher/service/next_wakeup_runner.py
+++ b/dispatcher/service/next_wakeup_runner.py
@@ -1,0 +1,101 @@
+import asyncio
+import logging
+import time
+from abc import abstractmethod
+from typing import Any, Callable, Coroutine, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class HasWakeup:
+    """A mixin to indicate that this class gives a future timestamp of when a call is needed"""
+
+    @abstractmethod
+    def next_wakeup(self) -> Optional[float]:
+        """The next time that we need to call the callback for, outline of contract:
+
+        return None - no need to call the callback
+        return positive value - however long we need to wait before calling the callback
+        return zero of negative value - callback needs to be called right away
+        """
+        ...
+
+
+def ensure_fatal(task: asyncio.Task) -> None:
+    "General utility to make sure errors are raised"
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        logger.info(f'Ack that task {task} was canceled')
+
+
+class NextWakeupRunner:
+    def __init__(self, wakeup_objects: Iterable[HasWakeup], callback: Callable[[], Coroutine[Any, Any, None]], name: Optional[str] = None):
+        self.wakeup_objects = wakeup_objects
+        self.callback = callback
+        self.asyncio_task: Optional[asyncio.Task] = None
+        self.kick_event = asyncio.Event()
+        self.shutting_down: bool = False
+        if name is None:
+            self.name = f'next-run-manager-of-{wakeup_objects}'
+        else:
+            self.name = name
+
+    def get_next_wakeup(self) -> Optional[float]:
+        """Get the soonest next-run time. A None value indicates no next-run"""
+        next_wakeup = None
+        for obj in self.wakeup_objects:
+            nr_item = obj.next_wakeup()
+            if nr_item is None:
+                continue
+            if next_wakeup is None:
+                next_wakeup = nr_item
+            elif nr_item < next_wakeup:
+                next_wakeup = nr_item
+        return next_wakeup
+
+    async def background_task(self):
+        while not self.shutting_down:
+            next_wakeup = self.get_next_wakeup()
+            if next_wakeup is None:
+                return
+
+            now_time = time.monotonic()
+            if next_wakeup <= now_time:
+                await self.callback()
+                next_wakeup = self.get_next_wakeup()
+                if next_wakeup is None:
+                    return
+
+            delta = next_wakeup - now_time
+            if delta >= 0.0:
+                try:
+                    asyncio.wait_for(self.kick_event, timeout=delta)
+                except asyncio.TimeoutError:
+                    pass  # intended mechanism to hit the next schedule
+                except asyncio.CancelledError:
+                    logger.info(f'Task {self.name} cancelled, returning')
+                    return
+
+            self.kick_event.clear()
+
+    def mk_new_task(self) -> None:
+        """Should only be called if a task is not currently running"""
+        self.asyncio_task = asyncio.create_task(self.background_task(), name=self.name)
+        self.asyncio_task.add_done_callback(ensure_fatal)
+
+    def kick(self):
+        """Initiates the asyncio task to wake up at the next run time
+
+        This needs to be called if objects in wakeup_objects are changed, for example
+        """
+        if not self.get_next_wakeup():
+            # Optimization here, if there is no next time, do not bother managing tasks
+            return
+        if self.asyncio_task:
+            if self.asyncio_task.done():
+                self.mk_new_task()
+            else:
+                self.kick_event.set()
+        else:
+            self.mk_new_task()

--- a/dispatcher/service/next_wakeup_runner.py
+++ b/dispatcher/service/next_wakeup_runner.py
@@ -70,7 +70,7 @@ class NextWakeupRunner:
             delta = next_wakeup - now_time
             if delta >= 0.0:
                 try:
-                    asyncio.wait_for(self.kick_event, timeout=delta)
+                    await asyncio.wait_for(self.kick_event.wait(), timeout=delta)
                 except asyncio.TimeoutError:
                     pass  # intended mechanism to hit the next schedule
                 except asyncio.CancelledError:

--- a/dispatcher/service/next_wakeup_runner.py
+++ b/dispatcher/service/next_wakeup_runner.py
@@ -36,6 +36,7 @@ class NextWakeupRunner:
     You want to run each on their period - this does that using one lazy asyncio task.
     This is a repeated pattern in the code base with task schedules, delays, and timeouts
     """
+
     def __init__(self, wakeup_objects: Iterable[HasWakeup], callback: Callable[[], Coroutine[Any, Any, None]], name: Optional[str] = None) -> None:
         self.wakeup_objects = wakeup_objects
         self.callback = callback
@@ -105,3 +106,7 @@ class NextWakeupRunner:
                 self.kick_event.set()
         else:
             self.mk_new_task()
+
+    async def shutdown(self):
+        self.shutting_down = True
+        self.kick()

--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -364,7 +364,7 @@ class WorkerPool:
         self.shutting_down = True
         self.events.management_event.set()
         self.timeout_runner.shutting_down = True
-        await self.timeout_runner.kick()
+        self.timeout_runner.kick()
         await self.stop_workers()
         self.process_manager.finished_queue.put('stop')
 

--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -363,8 +363,7 @@ class WorkerPool:
     async def shutdown(self) -> None:
         self.shutting_down = True
         self.events.management_event.set()
-        self.timeout_runner.shutting_down = True
-        self.timeout_runner.kick()
+        await self.timeout_runner.shutdown()
         await self.stop_workers()
         self.process_manager.finished_queue.put('stop')
 

--- a/tests/unit/service/test_next_wakeup_runner.py
+++ b/tests/unit/service/test_next_wakeup_runner.py
@@ -1,0 +1,78 @@
+import time
+from unittest import mock
+
+import pytest
+
+from dispatcher.service.next_wakeup_runner import NextWakeupRunner, HasWakeup
+
+
+class ObjectWithWakeup(HasWakeup):
+    def __init__(self, period):
+        self.period = period
+        self.last_run = time.monotonic()
+
+    def next_wakeup(self):
+        if self.period is None:
+            return None
+        return self.last_run + self.period
+
+
+def test_get_next_wakeup():
+    objects = set()
+    obj = ObjectWithWakeup(1)
+    objects.add(obj)
+    callback = mock.MagicMock()
+    runner = NextWakeupRunner(objects, callback)
+    assert runner.get_next_wakeup() > time.monotonic()
+    assert runner.get_next_wakeup() < time.monotonic() + 1.
+
+    obj.last_run = time.monotonic() + 0.1
+    assert runner.get_next_wakeup() > time.monotonic() + 1.
+
+    obj.period = None
+    assert runner.get_next_wakeup() is None
+
+    callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_and_exit_task():
+    objects = set()
+    obj = ObjectWithWakeup(0.01)  # runs in 0.01 seconds, test will take this long
+    objects.add(obj)
+
+    async def callback_makes_done():
+        obj.period = None  # No need to run ever again
+        callback_makes_done.is_called = True
+
+    runner = NextWakeupRunner(objects, callback_makes_done)
+
+    await runner.background_task()  # should finish
+
+    assert callback_makes_done.is_called is True
+
+
+@pytest.mark.asyncio
+async def test_graceful_shutdown():
+    objects = set()
+    obj = ObjectWithWakeup(1)
+    obj.last_run -= 1.0  # make first run immediate
+    objects.add(obj)
+    callback = mock.MagicMock()
+
+    async def mock_process_tasks():
+        obj.last_run = time.monotonic()  # did whatever we do with the things
+        callback()  # track for assertion
+
+    runner = NextWakeupRunner(objects, mock_process_tasks)
+
+    runner.kick()  # creates task, starts running
+
+    runner.shutting_down = True
+    runner.kick()
+    await runner.asyncio_task
+    assert runner.asyncio_task.done()
+
+    callback.assert_called_once_with()
+
+    assert runner.background_task.done() is True


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcher/issues/57

TODO: still need to apply this same tool to the `ScheduledProducer` because it's the 3rd version of the shared problem.

Before:
 - timeout watcher used 1 persistent task to watch for timeouts
 - delayed tasks used 1 task each

With this:
 - In all cases, either 0 or 1 task is running. That is, if there's no delayed task or task with a timeout, then we do not run a task. In all cases we rely on next-wakeup type logic, taken from the existing task timeout logic.